### PR TITLE
Change class name to cls() reference

### DIFF
--- a/matminer/data_retrieval/retrieve_AFLOW.py
+++ b/matminer/data_retrieval/retrieve_AFLOW.py
@@ -172,7 +172,7 @@ class RetrievalQuery(Query):
                 Note that this is similar to "limit" in pymongo.find.
         """
         # initializes query
-        query = RetrievalQuery(batch_size=request_size)
+        query = cls(batch_size=request_size)
 
         # adds filters to query
         query._add_filters(criteria)


### PR DESCRIPTION
Fixes issue with inheritance. Say one creates a class that inherits from `RetrievalQuery` called `MyQuery`. With the current implementation, `MyQuery.from_pymongo(...)` would return a `RetrievalQuery` object instead of a `MyQuery` object. With `cls`, it will return the type of the calling class.